### PR TITLE
Proxy support

### DIFF
--- a/teslajson.py
+++ b/teslajson.py
@@ -93,7 +93,6 @@ class Connection(object):
 
 		# Proxy support
 		if self.proxy_url is not None:
-			print "RSM have proxy url: %s" % self.proxy_url
 			if self.proxy_user is None:
 				handler = ProxyHandler({'https': self.proxy_url})
 				opener = build_opener(handler)

--- a/teslajson.py
+++ b/teslajson.py
@@ -28,16 +28,16 @@ import json
 class Connection(object):
 	"""Connection to Tesla Motors API"""
 	def __init__(self,
-			proxy_url = None,
-			proxy_user = None,
-			proxy_password = None,
 			email='',
 			password='',
 			access_token='',
 			url="https://owner-api.teslamotors.com",
 			api="/api/1/",
 			client_id = "e4a9949fcfa04068f59abb5a658f2bac0a3428e4652315490b659d5ab3f35a9e",
-			client_secret = "c75f14bbadc8bee3a7594412c31416f8300256d7668ea7e6e7f06727bfb9d220"):
+			client_secret = "c75f14bbadc8bee3a7594412c31416f8300256d7668ea7e6e7f06727bfb9d220",
+			proxy_url = None,
+			proxy_user = None,
+			proxy_password = None):
 		"""Initialize connection object
 		
 		Sets the vehicles field, a list of Vehicle objects
@@ -93,6 +93,7 @@ class Connection(object):
 
 		# Proxy support
 		if self.proxy_url is not None:
+			print "RSM have proxy url: %s" % self.proxy_url
 			if self.proxy_user is None:
 				handler = ProxyHandler({'https': self.proxy_url})
 				opener = build_opener(handler)


### PR DESCRIPTION
In the last week, the Tesla API became unresponsive from AWS. Whether that is on the outbound side blocked somewhere deep in AWS or on the Tesla inbound side nobody knows. The API works fine from other machines in Google Cloud, IBM Cloud, and various other locations. The impact of this block has been felt by many in the community including my project EVTripping.com and Teslab.

This change adds support for a proxy server to be passed into teslajson. For my own site, I've set up a proxy server elsewhere as I didn't want to relocate the whole site. So this allows just the Tesla API calls to proxy around the silly blockage.