### PR TITLE
Vulnerable validation of baseurl

### DIFF
--- a/teslajson.py
+++ b/teslajson.py
@@ -56,7 +56,7 @@ class Connection(object):
 		tesla_client = self.__open("/raw/0a8e0xTJ", baseurl="http://pastebin.com")
 		current_client = tesla_client['v1']
 		self.baseurl = current_client['baseurl']
-		if not self.baseurl.startswith('https:') or not self.baseurl.endswith(('teslamotors.com','tesla.com')):
+		if not self.baseurl.startswith('https:') or not self.baseurl.endswith(('.teslamotors.com','.tesla.com')):
 			raise IOError("Unexpected URL (%s) from pastebin" % self.baseurl)
 		self.api = current_client['api']
 		if access_token:


### PR DESCRIPTION
I can host malicious content on eviltesla.com and bypass your validation checks:
```
>>> "https://eviltesla.com".endswith(('teslamotors.com','tesla.com'))
True
```
Hence, I suggest you need to do a better input validation. One simple way to do this is by prefixing the naked domain with a dot, as shown in this PR.

However, IMHO, the baseurl for the API should be hardcoded into the module, not imported from a third party site. I do understand your rational for doing this, but it's a very insecure design.