### PR TITLE
Fix 408 Request Timeout errors with wake_up api call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ build/
 teslajson.egg-info/
 dist/
 MANIFEST
+.idea
+

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from codecs import open
 from os import path
 
 setup(name='teslajson',
-      version='1.3.1',
+      version='1.3.2',
       description='',
       url='https://github.com/gglockner/teslajson',
       py_modules=['teslajson'],

--- a/setup.py
+++ b/setup.py
@@ -10,4 +10,7 @@ setup(name='teslajson',
       py_modules=['teslajson'],
       author='Greg Glockner',
       license='MIT',
+      install_requires=[
+          'polling',
+      ]
       )

--- a/teslajson.py
+++ b/teslajson.py
@@ -170,10 +170,15 @@ class Vehicle(dict):
     def get(self, command):
         """Utility command to get data from API"""
         return self.connection.get('vehicles/%i/%s' % (self['id'], command))
-    
-    def post(self, command, data={}):
+
+    def post(self, command, data={}, timeout=35, step=3):
         """Utility command to post data to API"""
-        return self.connection.post('vehicles/%i/%s' % (self['id'], command), data)
+        return polling.poll(
+            lambda: self.connection.post('vehicles/%i/%s' % (self['id'], command), data) is not None,
+            ignore_exceptions=(ContinuePollingError,),
+            timeout=timeout,
+            step=step,
+        )
 
 
 class ContinuePollingError(Exception):

--- a/teslajson.py
+++ b/teslajson.py
@@ -157,12 +157,12 @@ class Vehicle(dict):
         if timeout is reached, TimeoutError is raised
         """
         return polling.poll(
-            lambda: self.post('wake_up'), # if returns any value then it woke up
+            lambda: self.post('wake_up') is not None,
             ignore_exceptions=(ContinuePollingError,),
             timeout=timeout,
             step=step,
         )
-    
+
     def command(self, name, data={}):
         """Run the command for the vehicle"""
         return self.post('command/%s' % name, data)
@@ -176,7 +176,7 @@ class Vehicle(dict):
         return self.connection.post('vehicles/%i/%s' % (self['id'], command), data)
 
 
-class ContinuePollingError (Exception):
+class ContinuePollingError(Exception):
     pass
 
 

--- a/teslajson.py
+++ b/teslajson.py
@@ -176,7 +176,7 @@ class Vehicle(dict):
         return self.connection.post('vehicles/%i/%s' % (self['id'], command), data)
 
 
-class ContinuePollingError (HTTPError):
+class ContinuePollingError (Exception):
     pass
 
 


### PR DESCRIPTION
The HTTP spec says for code 408 that 

> the client MAY repeat that request on a new connection.

So polling seems like the correct solution.